### PR TITLE
A few h2spec fixes

### DIFF
--- a/src/connection.cr
+++ b/src/connection.cr
@@ -30,9 +30,9 @@ module HTTP2
   class Connection
     property local_settings : Settings
     property remote_settings : Settings
-    private getter io : IO # ::FileDescriptor | OpenSSL::SSL::Socket
+    private getter io : IO #::FileDescriptor | OpenSSL::SSL::Socket
 
-    @logger : Logger | Logger::Dummy | Nil
+    @logger : Logger|Logger::Dummy|Nil
 
     def initialize(@io, @logger = nil)
       @local_settings = DEFAULT_SETTINGS.dup
@@ -74,7 +74,7 @@ module HTTP2
         rescue Channel::ClosedError
           break
         rescue ex
-          # logger.debug { "#{ex.class.name} #{ex.message}:\n#{ex.backtrace.join('\n')}" }
+          #logger.debug { "#{ex.class.name} #{ex.message}:\n#{ex.backtrace.join('\n')}" }
           logger.debug { "ERROR: #{ex.class.name} #{ex.message}" }
         end
       end
@@ -126,6 +126,7 @@ module HTTP2
             end
           end
         end
+
       when Frame::Type::HEADERS
         raise Error.protocol_error if stream.id == 0
         read_padded(frame) do |len|
@@ -167,6 +168,7 @@ module HTTP2
             end
           end
         end
+
       when Frame::Type::PUSH_PROMISE
         raise Error.protocol_error if stream.id == 0
         read_padded(frame) do |len|
@@ -178,6 +180,7 @@ module HTTP2
           buf = read_headers_payload(frame, buf.to_unsafe, len)
           hpack_decoder.decode(buf, stream.headers)
         end
+
       when Frame::Type::PRIORITY
         raise Error.protocol_error if stream.id == 0
         raise Error.frame_size_error unless frame.size == PRIORITY_FRAME_SIZE
@@ -186,11 +189,13 @@ module HTTP2
         weight = read_byte.to_i32 + 1
         stream.priority = Priority.new(exclusive == 1, dep_stream_id, weight)
         logger.debug { "  #{stream.priority.debug}" }
+
       when Frame::Type::RST_STREAM
         raise Error.protocol_error if stream.id == 0
         raise Error.frame_size_error unless frame.size == RST_STREAM_FRAME_SIZE
         error_code = Error::Code.new(io.read_bytes(UInt32, IO::ByteFormat::BigEndian))
         logger.debug { "  code=#{error_code.to_s}" }
+
       when Frame::Type::SETTINGS
         raise Error.protocol_error unless stream.id == 0
         raise Error.frame_size_error unless frame.size % 6 == 0
@@ -200,11 +205,13 @@ module HTTP2
           end
           send Frame.new(Frame::Type::SETTINGS, frame.stream, 0x1)
         end
+
       when Frame::Type::PING
         raise Error.protocol_error unless stream.id == 0
         raise Error.frame_size_error unless frame.size == PING_FRAME_SIZE
         io.read_fully(buf = Slice(UInt8).new(frame.size))
         send Frame.new(Frame::Type::PING, streams.find(0), 1, buf) unless frame.flags.ack?
+
       when Frame::Type::GOAWAY
         _, last_stream_id = read_stream_id
         error_code = Error::Code.from_value(io.read_bytes(UInt32, IO::ByteFormat::BigEndian))
@@ -217,21 +224,25 @@ module HTTP2
         unless error_code == Error::Code::NO_ERROR
           raise ClientError.new(error_code, last_stream_id, error_message)
         end
+
       when Frame::Type::WINDOW_UPDATE
         raise Error.frame_size_error unless frame.size == WINDOW_UPDATE_FRAME_SIZE
         buf = io.read_bytes(UInt32, IO::ByteFormat::BigEndian)
-        # reserved = buf.bit(31)
+        #reserved = buf.bit(31)
         window_size_increment = (buf & 0x7fffffff_u32).to_i32
         raise Error.protocol_error unless MINIMUM_WINDOW_SIZE <= window_size_increment <= MAXIMUM_WINDOW_SIZE
 
         logger.debug { "  WINDOW_SIZE_INCREMENT=#{window_size_increment}" }
+        stream.increment_window_size(window_size_increment)
 
         unless stream.increment_window_size(window_size_increment)
           raise Error.flow_control_error if stream.id == 0
           stream.send_rst_stream(Error::Code::FLOW_CONTROL_ERROR)
         end
+
       when Frame::Type::CONTINUATION
         Error.protocol_error("UNEXPECTED continuation frame")
+
       else
         io.skip(frame.size)
       end
@@ -332,7 +343,7 @@ module HTTP2
       end
 
       if flush
-        io.flush # unless io.sync?
+        io.flush #unless io.sync?
       end
     end
 

--- a/src/server/request_processor.cr
+++ b/src/server/request_processor.cr
@@ -1,5 +1,5 @@
 require "base64"
-#require "io/hexdump"
+# require "io/hexdump"
 require "./context"
 require "./response"
 
@@ -9,7 +9,7 @@ class HTTP::Server::RequestProcessor
   def process(io, alpn, logger)
     must_close = true
 
-    #io = IO::Hexdump.new(io, read: true)
+    # io = IO::Hexdump.new(io, read: true)
 
     if alpn == "h2"
       handle_http2_client(io, alpn: alpn, logger: logger)
@@ -73,17 +73,14 @@ class HTTP::Server::RequestProcessor
         # didn't read it all, for the next request
         request.body.try(&.close)
       end
-
     rescue ex : Errno
       # FIXME: calling with curl results in EPIPE (certainly related to
       #        SSL::Error below)
       raise ex unless ex.errno == Errno::EPIPE
-
     rescue ex : OpenSSL::SSL::Error
       # FIXME: calling with curl results in "SSL_read: ZERO_RETURN" exception
       #        (certainly related to EPIPE above)
       raise ex unless ex.message.try(&.includes?("ZERO_RETURN"))
-
     ensure
       io.close if must_close
     end
@@ -139,24 +136,19 @@ class HTTP::Server::RequestProcessor
         headers = validate_http2_headers(frame.stream.headers)
         request = Request.new(headers[":method"], headers[":path"], headers, version: "HTTP/2.0")
         spawn handle_http2_request(frame.stream, request)
-
       when HTTP2::Frame::Type::PUSH_PROMISE
         raise HTTP2::Error.protocol_error("UNEXPECTED push promise frame")
-
       when HTTP2::Frame::Type::GOAWAY
         break
       end
     end
-
   rescue err : HTTP2::ClientError
     logger.debug { "#{err.code}: #{err.message}" }
-
   rescue err : HTTP2::Error
     if connection
       connection.close(error: err) unless connection.closed?
     end
     logger.debug { "#{err.code}: #{err.message}" }
-
   ensure
     if connection
       connection.close unless connection.closed?
@@ -182,7 +174,7 @@ class HTTP::Server::RequestProcessor
       # special colon (:) headers MUST come before the regular headers
       regular ||= !name.starts_with?(':')
 
-      if (name.starts_with?(':') && (regular || !HTTP2::REQUEST_PSEUDO_HEADERS.includes?(name))) || ("A" .. "Z").covers?(name)
+      if (name.starts_with?(':') && (regular || !HTTP2::REQUEST_PSEUDO_HEADERS.includes?(name))) || ("A".."Z").covers?(name)
         raise HTTP2::Error.protocol_error("MALFORMED #{name} header")
       end
       if name == "connection"
@@ -202,7 +194,9 @@ class HTTP::Server::RequestProcessor
         raise HTTP2::Error.protocol_error("INVALID :scheme pseudo-header")
       end
 
-      unless headers.get?(":path").try(&.size) == 1
+      maybe_paths = headers.get?(":path")
+      first_path = maybe_paths.try(&.first)
+      unless maybe_paths.try(&.size) == 1 && !first_path.nil? && !first_path.empty?
         raise HTTP2::Error.protocol_error("INVALID :path pseudo-header")
       end
     end

--- a/src/stream.cr
+++ b/src/stream.cr
@@ -59,8 +59,8 @@ module HTTP2
 
     def active?
       state == State::OPEN ||
-        state == State::HALF_CLOSED_LOCAL ||
-        state == State::HALF_CLOSED_REMOTE
+      state == State::HALF_CLOSED_LOCAL ||
+      state == State::HALF_CLOSED_REMOTE
     end
 
     def data?
@@ -239,6 +239,7 @@ module HTTP2
         else
           error!(receiving)
         end
+
       when State::RESERVED_LOCAL
         error!(receiving) if receiving
 
@@ -250,6 +251,7 @@ module HTTP2
         else
           error!(receiving)
         end
+
       when State::RESERVED_REMOTE
         error!(receiving) unless receiving
 
@@ -261,6 +263,7 @@ module HTTP2
         else
           error!(receiving)
         end
+
       when State::OPEN
         case frame.type
         when Frame::Type::HEADERS, Frame::Type::DATA
@@ -274,16 +277,18 @@ module HTTP2
         else
           error!(receiving)
         end
+
       when State::HALF_CLOSED_LOCAL
-        # if sending
+        #if sending
         #  case frame.type
         #  when Frame::Type::HEADERS, Frame::Type::CONTINUATION, Frame::Type::DATA
         #    raise Error.stream_closed("STREAM #{id} is #{state}")
         #  end
-        # end
+        #end
         if frame.flags.end_stream? || frame.type == Frame::Type::RST_STREAM
           self.state = State::CLOSED
         end
+
       when State::HALF_CLOSED_REMOTE
         if receiving
           case frame.type
@@ -294,6 +299,7 @@ module HTTP2
         if frame.flags.end_stream? || frame.type == Frame::Type::RST_STREAM
           self.state = State::CLOSED
         end
+
       when State::CLOSED
         case frame.type
         when Frame::Type::WINDOW_UPDATE, Frame::Type::RST_STREAM

--- a/src/stream.cr
+++ b/src/stream.cr
@@ -59,8 +59,8 @@ module HTTP2
 
     def active?
       state == State::OPEN ||
-      state == State::HALF_CLOSED_LOCAL ||
-      state == State::HALF_CLOSED_REMOTE
+        state == State::HALF_CLOSED_LOCAL ||
+        state == State::HALF_CLOSED_REMOTE
     end
 
     def data?
@@ -99,6 +99,7 @@ module HTTP2
           # resume fiber waiting to send data
           fiber.resume
         end
+        true
       end
     end
 
@@ -238,7 +239,6 @@ module HTTP2
         else
           error!(receiving)
         end
-
       when State::RESERVED_LOCAL
         error!(receiving) if receiving
 
@@ -250,7 +250,6 @@ module HTTP2
         else
           error!(receiving)
         end
-
       when State::RESERVED_REMOTE
         error!(receiving) unless receiving
 
@@ -262,7 +261,6 @@ module HTTP2
         else
           error!(receiving)
         end
-
       when State::OPEN
         case frame.type
         when Frame::Type::HEADERS, Frame::Type::DATA
@@ -276,18 +274,16 @@ module HTTP2
         else
           error!(receiving)
         end
-
       when State::HALF_CLOSED_LOCAL
-        #if sending
+        # if sending
         #  case frame.type
         #  when Frame::Type::HEADERS, Frame::Type::CONTINUATION, Frame::Type::DATA
         #    raise Error.stream_closed("STREAM #{id} is #{state}")
         #  end
-        #end
+        # end
         if frame.flags.end_stream? || frame.type == Frame::Type::RST_STREAM
           self.state = State::CLOSED
         end
-
       when State::HALF_CLOSED_REMOTE
         if receiving
           case frame.type
@@ -298,7 +294,6 @@ module HTTP2
         if frame.flags.end_stream? || frame.type == Frame::Type::RST_STREAM
           self.state = State::CLOSED
         end
-
       when State::CLOSED
         case frame.type
         when Frame::Type::WINDOW_UPDATE, Frame::Type::RST_STREAM


### PR DESCRIPTION
Hey there,

I thought I'd work on this project a little bit. I ran the h2spec and found 13 failing tests.

I fixed 5 of those. Most of them were easy picking:
- `generic/2/2` - Sends a WINDOW_UPDATE frame on half-closed (remote) stream
- `generic/2/3` - Sends a PRIORITY frame on half-closed (remote) stream
- `generic/3.9/1` - Sends a WINDOW_UPDATE frame with stream ID 0
- `generic/3.9/2` - Sends a WINDOW_UPDATE frame with stream ID 1
- `http2/8.1.2.3/1` - Sends a HEADERS frame with empty ":path" pseudo-header field

There are still 8 broken tests!

There's one with setting the initial window size. I think you're doing that right, but the test fails because it's getting an old stream instead of a new one (I think.)

A lot of http2 is way over my head, but it seems far more doable when using `h2spec`.

There are some hpack issues, they don't seem too hard to fix.