### PR TITLE
Fix: Crystal 0.24.0 compatibility

### DIFF
--- a/src/data.cr
+++ b/src/data.cr
@@ -1,7 +1,5 @@
 module HTTP2
-  class Data
-    include IO
-
+  class Data < IO
     getter size : Int32
     @r : IO #::FileDescriptor
     @w : IO #::FileDescriptor

--- a/src/io/circular_buffer.cr
+++ b/src/io/circular_buffer.cr
@@ -40,9 +40,7 @@
 # io = IO::CircularBuffer.new(16)
 # io.read(Bytes.new(8))
 # ```
-class IO::CircularBuffer
-  include IO
-
+class IO::CircularBuffer < IO
   @[Flags]
   enum Closed
     Read

--- a/src/io/hexdump.cr
+++ b/src/io/hexdump.cr
@@ -1,6 +1,4 @@
-class IO::Hexdump
-  include IO
-
+class IO::Hexdump < IO
   def initialize(@io : IO, @logger : Logger|Logger::Dummy, @read = true, @write = true)
   end
 


### PR DESCRIPTION
`IO` is now a class. A harmless change...

Except this shard hacks into `HTTP::Server::Response` and duplicates `Output` (HTTP/1: write to socket) and `StreamOutput` (HTTP/2: write to stream), which causes `@original_output` to become an union,
which crystal *always* reduces to the same parent, that is `IO+`, even when the union is specifically declared, and `IO` obviously doesn't declare the expected `#reset` method.

This patch fixes this by introducing a module, and casting `@original_output` as `IO` when assigning to `@output`, which requires to duplicate the `HTTP::Server::Response#reset` method :cry: 