### PR TITLE
Configure Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+dist: trusty
+sudo: required
+
+language: crystal
+
+env:
+  global:
+    - H2SPEC=2.1.0
+
+before_install:
+  - bin/ci setup
+  - shards install
+
+install:
+  - make bin/h
+  - bin/ci run
+
+script:
+  - make test
+  - bin/h2spec --strict --port 9393 --tls --insecure
+
+  # NOTE: disabled because of random failures:
+  #- bin/h2spec --strict --port 9292

--- a/bin/ci
+++ b/bin/ci
@@ -1,0 +1,32 @@
+#! /usr/bin/env sh
+set -e
+set -x
+
+case "$1" in
+  setup)
+      # install h2spec
+      curl -sL "https://github.com/summerwind/h2spec/releases/download/v$H2SPEC/h2spec_linux_amd64.tar.gz" | tar zx -C bin
+      bin/h2spec --version
+
+      # update OpenSSL (to support ALPN)
+      curl -sOL "http://security.ubuntu.com/ubuntu/pool/main/o/openssl/openssl_1.0.2g-1ubuntu4.6_amd64.deb"
+      curl -sOL "http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.0.0_1.0.2g-1ubuntu4.6_amd64.deb"
+      curl -sOL "http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl-dev_1.0.2g-1ubuntu4.6_amd64.deb"
+      sudo dpkg -i *.deb
+
+      # create SSL certificates
+      mkdir -p ssl
+      openssl genrsa -out "ssl/server.key" 2048
+      openssl req -new -key "ssl/server.key" -out "ssl/server.csr" -subj "/C=/ST=/L=/O=Local Cert/OU=/CN=localhost"
+      openssl x509 -req -days 365 -in "ssl/server.csr" -signkey "ssl/server.key" -out "ssl/server.crt"
+      ;;
+
+  run)
+      # start HTTP servers
+      make run PORT=9292 2>/dev/null &
+      make run PORT=9393 TLS=true 2>/dev/null &
+
+      # make sure servers started
+      sleep 1
+      ;;
+esac

--- a/h.cr
+++ b/h.cr
@@ -13,6 +13,10 @@ server = HTTP::Server.new(host, port) do |context|
   response << "Served with #{request.version}\n"
 end
 
+if ENV["CI"]?
+  server.logger = Logger::Dummy.new(File.open("/dev/null"))
+end
+
 if tls
   tls_context = HTTP::Server.default_tls_context
   tls_context.certificate_chain = File.join("ssl", "server.crt")

--- a/src/connection.cr
+++ b/src/connection.cr
@@ -7,7 +7,7 @@ require "./hpack"
 require "./settings"
 require "./streams"
 
-class Logger::Dummy
+class Logger::Dummy < Logger
   {% for name in Logger::Severity.constants %}
     def {{ name.downcase }}?
       false
@@ -35,7 +35,7 @@ module HTTP2
     getter hpack_encoder : HPACK::Encoder
     getter hpack_decoder : HPACK::Decoder
 
-    @logger : Logger|Logger::Dummy|Nil
+    @logger : Logger?
 
     def initialize(@io, @logger = nil)
       @local_settings = DEFAULT_SETTINGS.dup
@@ -60,7 +60,7 @@ module HTTP2
     end
 
     def logger
-      @logger ||= Logger::Dummy.new
+      @logger ||= Logger::Dummy.new(File.open("/dev/null"))
     end
 
     def logger=(@logger)

--- a/src/server.cr
+++ b/src/server.cr
@@ -31,6 +31,9 @@ module HTTP
       end
     end
 
+    def logger=(@logger)
+    end
+
     def handle_client(io)
       return unless io
       io.sync = true

--- a/src/server/request_processor.cr
+++ b/src/server/request_processor.cr
@@ -34,6 +34,11 @@ class HTTP::Server::RequestProcessor
           return
         end
 
+        unless {"HTTP/1.0", "HTTP/1.1"}.includes?(request.version)
+          response.close
+          return
+        end
+
         response.version = request.version
         response.reset
 


### PR DESCRIPTION
- installs OpenSSL 1.0.2 from Ubuntu 16.04 (xenial) for ALPN support;
- installs h2spec —version is configured in `.travis.yml`;
- runs unit tests;
- builds `bin/h` test server, then runs h2spec over TLS only.

Note: running specs over HTTP has been disabled because some spec randomly fail (reproduced in local).