### PR TITLE
Make it work with GRPC

### DIFF
--- a/src/connection.cr
+++ b/src/connection.cr
@@ -362,7 +362,7 @@ module HTTP2
           raise Error.protocol_error("MALFORMED #{name} header")
         end
 
-        if name == "te" && value != "trailers"
+        if name == "te" && !(value == "trailers" || value == %w[trailers])
           raise Error.protocol_error("MALFORMED #{name} header")
         end
       end

--- a/src/server/http1.cr
+++ b/src/server/http1.cr
@@ -83,7 +83,7 @@ module HTTP1
 
     def send_headers(headers : HTTP::Headers)
       status = headers[":status"]
-      message = HTTP.default_status_message_for(status.to_i)
+      message = HTTP::Status.new(status.to_i).description
       @io << @version << ' ' << status << ' ' << message << "\r\n"
 
       headers.each do |name, values|


### PR DESCRIPTION
Since GRPC runs on top of HTTP/2, it seemed like a good way to do some real-world test cases.

I'm not super familiar with HTTP/2 so these tweaks were driven by error messages that came up when making GRPC calls using the official Google GRPC Ruby client to my Crystal GRPC server.

For context, here is the `call` method from my `HTTP2::Server::Handler` implementation:

```crystal
    def call(context : HTTP2::Server::Context)
      request, response = context.request, context.response

      compressed = request.body.read_bytes(UInt8) == 1 # ¯\_(ツ)_/¯
      length = request.body.read_bytes(UInt32, IO::ByteFormat::BigEndian)

      # TODO: Do some routing to dynamically map to the service and method
      buffer = CatalogHandler.new
        # .get_product(ProductRequest.from_protobuf(request.body))
        .get_products(pp ProductSearchQuery.from_protobuf(request.body))
        .to_protobuf

      response.headers["content-type"] = "application/grpc+proto"

      # Required for GRPC
      response.trailing_headers["grpc-status"] = "0"

      response.write_bytes 0_u8, IO::ByteFormat::BigEndian
      response.write_bytes buffer.bytesize, IO::ByteFormat::BigEndian

      buffer.rewind.to_s response
    end
```

I still get a few of these during requests but I can't tell if they're due to GRPC stuff or HTTP/2 stuff:

```
Unhandled exception in spawn: End of file reached (IO::EOFError)
  from /usr/local/Cellar/crystal/0.30.1/src/io.cr:513:27 in 'read_fully'
  from /usr/local/Cellar/crystal/0.30.1/src/io/byte_format.cr:131:3 in 'decode'
  from /usr/local/Cellar/crystal/0.30.1/src/int.cr:535:5 in 'from_io'
  from /usr/local/Cellar/crystal/0.30.1/src/io.cr:889:5 in 'read_bytes'
  from lib/http2/src/connection.cr:234:7 in 'read_frame_header'
  from lib/http2/src/connection.cr:164:7 in 'receive'
  from lib/http2/src/server.cr:177:24 in 'handle_http2_connection'
  from lib/http2/src/server.cr:151:13 in 'handle_http2_connection'
  from lib/http2/src/server.cr:93:20 in 'handle_socket'
  from lib/http2/src/server.cr:32:14 in '->'
  from /usr/local/Cellar/crystal/0.30.1/src/fiber.cr:255:3 in 'run'
  from /usr/local/Cellar/crystal/0.30.1/src/fiber.cr:47:34 in '->'
```