### PR TITLE
Fix: `HTTP2::Settings` values must be `UInt32`

### DIFF
--- a/src/connection.cr
+++ b/src/connection.cr
@@ -376,10 +376,10 @@ module HTTP2
 
         case id
         when Settings::Identifier::HEADER_TABLE_SIZE
-          hpack_decoder.max_table_size = value
+          hpack_decoder.max_table_size = value.to_i32
 
         when Settings::Identifier::INITIAL_WINDOW_SIZE
-          difference = value - remote_settings.initial_window_size
+          difference = value.to_i32 - remote_settings.initial_window_size
 
           # adjust windows size for all control-flow streams (doesn't affect
           # the connection window size):

--- a/src/settings.cr
+++ b/src/settings.cr
@@ -13,20 +13,20 @@ module HTTP2
       MAX_HEADER_LIST_SIZE   = 0x6
     end
 
-    setter header_table_size : Int32
+    setter header_table_size : UInt32
     setter enable_push : Bool
-    setter max_concurrent_streams : Int32
-    getter max_concurrent_streams : Int32?
-    setter initial_window_size : Int32
-    setter max_header_list_size : Int32
-    getter max_header_list_size : Int32?
+    setter max_concurrent_streams : UInt32
+    getter max_concurrent_streams : UInt32?
+    setter initial_window_size : UInt32
+    setter max_header_list_size : UInt32
+    getter max_header_list_size : UInt32?
 
-    @header_table_size : Int32?
+    @header_table_size : UInt32?
     @enable_push : Bool?
-    @max_concurrent_streams : Int32?
-    @initial_window_size : Int32?
-    @max_frame_size : Int32?
-    @max_header_list_size : Int32?
+    @max_concurrent_streams : UInt32?
+    @initial_window_size : UInt32?
+    @max_frame_size : UInt32?
+    @max_header_list_size : UInt32?
 
     # :nodoc:
     protected def initialize(
@@ -40,7 +40,7 @@ module HTTP2
     end
 
     def header_table_size : Int32
-      @header_table_size || DEFAULT_HEADER_TABLE_SIZE
+      (@header_table_size || DEFAULT_HEADER_TABLE_SIZE).to_i32
     end
 
     def enable_push : Bool
@@ -48,23 +48,23 @@ module HTTP2
     end
 
     def initial_window_size : Int32
-      @initial_window_size || DEFAULT_INITIAL_WINDOW_SIZE
+      (@initial_window_size || DEFAULT_INITIAL_WINDOW_SIZE).to_i32
     end
 
-    def initial_window_size=(size : Int32)
+    def initial_window_size=(size : Int)
       raise Error.flow_control_error unless 0 <= size < MAXIMUM_WINDOW_SIZE
-      @initial_window_size = size
+      @initial_window_size = size.to_u32
     end
 
     def max_frame_size : Int32
-      @max_frame_size || DEFAULT_MAX_FRAME_SIZE
+      (@max_frame_size || DEFAULT_MAX_FRAME_SIZE).to_i32
     end
 
-    def max_frame_size=(size : Int32)
+    def max_frame_size=(size : Int)
       unless MINIMUM_FRAME_SIZE <= size < MAXIMUM_FRAME_SIZE
         raise Error.protocol_error("INVALID frame size: #{size}")
       end
-      @max_frame_size = size
+      @max_frame_size = size.to_u32
     end
 
     def parse(bytes : Bytes, &) : Nil
@@ -76,7 +76,7 @@ module HTTP2
     def parse(io : IO, size : Int32, &) : Nil
       size.times do |i|
         id = Identifier.from_value?(io.read_bytes(UInt16, IO::ByteFormat::BigEndian))
-        value = io.read_bytes(UInt32, IO::ByteFormat::BigEndian).to_i32
+        value = io.read_bytes(UInt32, IO::ByteFormat::BigEndian)
         next unless id # unknown setting identifier
 
         yield id, value
@@ -108,7 +108,7 @@ module HTTP2
           if value.is_a?(Bool)
             io.write_bytes(value ? 1_u32 : 0_u32, IO::ByteFormat::BigEndian)
           else
-            io.write_bytes(value.to_u32, IO::ByteFormat::BigEndian)
+            io.write_bytes(value, IO::ByteFormat::BigEndian)
           end
         end
       {% end %}

--- a/src/settings.cr
+++ b/src/settings.cr
@@ -13,14 +13,6 @@ module HTTP2
       MAX_HEADER_LIST_SIZE   = 0x6
     end
 
-    setter header_table_size : UInt32
-    setter enable_push : Bool
-    setter max_concurrent_streams : UInt32
-    getter max_concurrent_streams : UInt32?
-    setter initial_window_size : UInt32
-    setter max_header_list_size : UInt32
-    getter max_header_list_size : UInt32?
-
     @header_table_size : UInt32?
     @enable_push : Bool?
     @max_concurrent_streams : UInt32?
@@ -43,8 +35,24 @@ module HTTP2
       (@header_table_size || DEFAULT_HEADER_TABLE_SIZE).to_i32
     end
 
+    def header_table_size=(value : Int)
+      @header_table_size = value.to_u32
+    end
+
     def enable_push : Bool
       @enable_push || DEFAULT_ENABLE_PUSH
+    end
+
+    def enable_push=(value : Bool)
+      @enable_push = value
+    end
+
+    def max_concurrent_streams : UInt32?
+      @max_concurrent_streams
+    end
+
+    def max_concurrent_streams=(value : Int)
+      @max_concurrent_streams = value.to_u32
     end
 
     def initial_window_size : Int32
@@ -65,6 +73,14 @@ module HTTP2
         raise Error.protocol_error("INVALID frame size: #{size}")
       end
       @max_frame_size = size.to_u32
+    end
+
+    def max_header_list_size : Int32?
+      @max_header_list_size.try(&.to_i32)
+    end
+
+    def max_header_list_size=(value : Int)
+      @max_header_list_size = value.to_u32
     end
 
     def parse(bytes : Bytes, &) : Nil


### PR DESCRIPTION
The settings values are actually unsigned, and while we properly parsed them as such, we transformed the values to a signed integer, which overflows when the remote settings are larger than Int32::MAX.

Most settings are required to be much lower than Int32::MAX and the other values list SETTINGS_HEADER_TABLE_SIZE make no sense to use such absurd values, but some remote set SETTINGS_MAX_CONCURRENT_STREAMS to UInt32::MAX, maybe as a mean to say "no limit".

This patch changes the HTTP2::Settings ivars to become UInt32 and still casts most values to Int32 when accessing them because it makes no sense to even come close to Int32::MAX, but `#max_concurrent_streams` now returns an UInt32 to avoid an overflow error.

closes #23 