### PR TITLE
Fix attempt to lock mutex recursively error

### DIFF
--- a/src/streams.cr
+++ b/src/streams.cr
@@ -70,7 +70,7 @@ module HTTP2
 
     # Counts active ingnoring (type=1) or outgoing (type=0) streams.
     protected def active_count(type) : Int32
-      @mutex.synchronize { active_count(type) }
+      @mutex.synchronize { unsafe_active_count(type) }
     end
 
     private def unsafe_active_count(type) : Int32


### PR DESCRIPTION
Under heavy load with multiple streams, this would happen inside read_data_frame > consume_inbound_window_size > active_count consistently. This *seems* like what was intended but I could be misreading things!