### PR TITLE
Fix HPACK Huffman padding validation

### DIFF
--- a/src/hpack/huffman.cr
+++ b/src/hpack/huffman.cr
@@ -62,12 +62,12 @@ module HTTP2
         io = IO::Memory.new
         node = tree
         eos_padding = true
+        padding_length = 0
 
         bytes.each do |byte|
-          byte_has_value = false
-          eos_padding = true
-
           7.downto(0) do |i|
+            padding_length += 1
+
             if byte.bit(i) == 1
               node = node.right
             else
@@ -81,17 +81,17 @@ module HTTP2
               io.write_byte(value)
               node = tree
 
-              byte_has_value = true
               eos_padding = true
+              padding_length = 0
             end
           end
-
-          # RFC 7541, section 5.2
-          raise Error.new("huffman string padding is larger than 7-bits") unless byte_has_value
         end
 
         # RFC 7541, section 5.2
-        raise Error.new("huffman string padding must use MSB of EOS symbol") unless eos_padding
+        unless node == tree
+          raise Error.new("huffman string padding is larger than 7-bits") if padding_length > 7
+          raise Error.new("huffman string padding must use MSB of EOS symbol") unless eos_padding
+        end
 
         io.to_s
       end

--- a/test/hpack/decoder_test.cr
+++ b/test/hpack/decoder_test.cr
@@ -147,6 +147,13 @@ module HTTP2::HPACK
       assert_equal({":authority", "www.example.com"}, d.indexed(64))
     end
 
+    def test_huffman_string_may_span_bytes_without_completing_a_symbol_each_byte
+      value = "/cookies/set?kn1=kv1"
+      encoded = HPACK.huffman.encode(value)
+
+      assert_equal value, HPACK.huffman.decode(encoded)
+    end
+
     # http://tools.ietf.org/html/rfc7541#appendix-C.5
     def test_responses_without_huffman_encoding
       skip


### PR DESCRIPTION
The Huffman decoder rejected some valid strings because it required every input byte to complete at least one decoded symbol. That is stricter than RFC 7541 padding rules: a symbol may span byte boundaries, and only the final incomplete symbol path must be validated as EOS-prefix padding of at most seven bits.

This came up while sending HTTP/2 request headers for a path like /cookies/set?kn1=kv1. The encoder produced a valid Huffman string, but the peer decoder raised a padding error and the connection failed with COMPRESSION_ERROR. The fix tracks the number of pending bits since the last decoded symbol and validates padding only at the end of the string.

(This commit has been authored by AI and reviewed fully by myself. I've got three other AI generated, human verified commits to fix various issues. If you disallow AI code, or would like something rewritten, just let me know.)
