### PR TITLE
Expose received RST_STREAM error codes

### DIFF
--- a/src/connection.cr
+++ b/src/connection.cr
@@ -364,6 +364,7 @@ module HTTP2
     private def read_rst_stream_frame(frame)
       raise Error.frame_size_error unless frame.size == RST_STREAM_FRAME_SIZE
       error_code = Error::Code.new(io.read_bytes(UInt32, IO::ByteFormat::BigEndian))
+      frame.reset_error_code = error_code
       Log.trace { "  code=#{error_code.to_s}" }
     end
 

--- a/src/frame.cr
+++ b/src/frame.cr
@@ -58,10 +58,8 @@ module HTTP2
 
     getter! payload : Bytes
 
-    @reset_error_code : Error::Code? = nil
-    @size : Int32?
-
     getter reset_error_code : Error::Code?
+    @size : Int32?
 
     protected def reset_error_code=(code : Error::Code)
       @reset_error_code = code

--- a/src/frame.cr
+++ b/src/frame.cr
@@ -58,7 +58,14 @@ module HTTP2
 
     getter! payload : Bytes
 
+    @reset_error_code : Error::Code? = nil
     @size : Int32?
+
+    getter reset_error_code : Error::Code?
+
+    protected def reset_error_code=(code : Error::Code)
+      @reset_error_code = code
+    end
 
     # :nodoc:
     protected def initialize(@type : Type, @stream : Stream, @flags : Flags = Flags::None, @payload : Bytes? = nil, size : Int32? = nil)

--- a/test/connection_test.cr
+++ b/test/connection_test.cr
@@ -1,0 +1,38 @@
+require "./test_helper"
+require "../src/connection"
+
+module HTTP2
+  class ConnectionTest < Minitest::Test
+    def test_rst_stream_exposes_error_code
+      headers = HPACK::Encoder.new(huffman: false).encode(HTTP::Headers{
+        ":status" => "200",
+      })
+      io = IO::Memory.new(
+        raw_frame(Frame::Type::HEADERS, Frame::Flags::END_HEADERS, 1, headers) +
+        raw_frame(Frame::Type::RST_STREAM, Frame::Flags::None, 1, Bytes[0, 0, 0, 7])
+      )
+      connection = Connection.new(io, Connection::Type::CLIENT)
+
+      connection.receive
+      frame = connection.receive.not_nil!
+
+      assert_equal Frame::Type::RST_STREAM, frame.type
+      assert_equal Error::Code::REFUSED_STREAM, frame.reset_error_code
+    end
+
+    private def raw_frame(type, flags, stream_id, payload = Bytes.empty)
+      frame = IO::Memory.new
+      frame.write_byte(((payload.size >> 16) & 0xff).to_u8)
+      frame.write_byte(((payload.size >> 8) & 0xff).to_u8)
+      frame.write_byte((payload.size & 0xff).to_u8)
+      frame.write_byte(type.value.to_u8)
+      frame.write_byte(flags.value.to_u8)
+      frame.write_byte(((stream_id >> 24) & 0x7f).to_u8)
+      frame.write_byte(((stream_id >> 16) & 0xff).to_u8)
+      frame.write_byte(((stream_id >> 8) & 0xff).to_u8)
+      frame.write_byte((stream_id & 0xff).to_u8)
+      frame.write(payload)
+      frame.to_slice
+    end
+  end
+end


### PR DESCRIPTION
The connection reader consumed the four-byte RST_STREAM error code and only logged it. Callers that receive the frame could tell that a stream was reset, but they could not distinguish REFUSED_STREAM from CANCEL, PROTOCOL_ERROR, or other reset reasons without parsing the wire bytes themselves.

This came up while mapping HTTP/2 failures into client-library errors. A REFUSED_STREAM reset should be handled differently from a generic reset, but the frame returned from Connection#receive had lost that information. The fix stores the decoded Error::Code on the Frame as reset_error_code while preserving the existing frame flow.

I wasn't sure if you'd want reset_error_code to be Error::Code::NoError by default, but you had other nilable properties so I went with it.
(AI written, human verified.)
