### PR TITLE
Fix max concurrent stream counting

### DIFF
--- a/src/connection.cr
+++ b/src/connection.cr
@@ -513,7 +513,7 @@ module HTTP2
 
       # if @inbound_window_size <= 0
       if @inbound_window_size < (initial_window_size // 2)
-        increment = Math.min(initial_window_size * streams.active_count(1), MAXIMUM_WINDOW_SIZE)
+        increment = Math.min(initial_window_size * streams.active_remote_count, MAXIMUM_WINDOW_SIZE)
         @inbound_window_size += increment
         streams.find(0).send_window_update_frame(increment)
       end

--- a/src/streams.cr
+++ b/src/streams.cr
@@ -2,17 +2,36 @@ require "./stream"
 
 module HTTP2
   class Streams
+    enum Endpoint
+      CLIENT
+      SERVER
+
+      def peer : Endpoint
+        client? ? SERVER : CLIENT
+      end
+
+      def first_stream_id : Int32
+        client? ? 1 : 2
+      end
+
+      def initiates?(stream_id : Int32) : Bool
+        # RFC 9113 assigns odd stream IDs to client-initiated streams and even
+        # stream IDs to server-initiated streams. This compares the stream ID's
+        # oddness to whether this endpoint is the client; it does not rely on
+        # enum numeric values.
+        stream_id > 0 && stream_id.odd? == client?
+      end
+    end
+
     # :nodoc:
     protected def initialize(@connection : Connection, type : Connection::Type)
       @streams = {} of Int32 => Stream
       @mutex = Mutex.new  # OPTIMIZE: use Sync::RWLock instead
       @highest_remote_id = 0
 
-      if type.server?
-        @id_counter = 0
-      else
-        @id_counter = -1
-      end
+      @local_endpoint = type.server? ? Endpoint::SERVER : Endpoint::CLIENT
+      @remote_endpoint = @local_endpoint.peer
+      @id_counter = @local_endpoint.first_stream_id - 2
     end
 
     # Finds an existing stream, silently creating it if it doesn't exist yet.
@@ -24,11 +43,14 @@ module HTTP2
     def find(id : Int32, consume : Bool = true) : Stream
       @mutex.synchronize do
         @streams[id] ||= begin
-          if max = @connection.local_settings.max_concurrent_streams
-            if unsafe_active_count(1) >= max
-              raise Error.refused_stream("MAXIMUM capacity reached")
+          if @remote_endpoint.initiates?(id)
+            if max = @connection.local_settings.max_concurrent_streams
+              if unsafe_active_count_initiated_by(@remote_endpoint) >= max
+                raise Error.refused_stream("MAXIMUM peer-initiated stream capacity reached")
+              end
             end
           end
+
           if id > @highest_remote_id && consume
             @highest_remote_id = id
           end
@@ -45,12 +67,12 @@ module HTTP2
 
     # Returns true if the incoming stream id is valid for the current connection.
     protected def valid?(id : Int32)
-      id == 0 || (                                 # stream #0 is always valid
-        (id % 2) == 1 && (                         # incoming streams are odd-numbered
-          @mutex.synchronize { @streams[id]? } ||  # streams already exists
-          id >= @highest_remote_id                 # stream ids must grow (not shrink)
-        )
-      )
+      # Stream #0 is the connection control stream, and existing streams may
+      # have been initiated by either endpoint.
+      return true if id == 0
+      return true if @mutex.synchronize { @streams[id]? }
+
+      @remote_endpoint.initiates?(id) && id >= @highest_remote_id
     end
 
     # Creates an outgoing stream. For example to handle a client request or a
@@ -58,8 +80,8 @@ module HTTP2
     def create(state = Stream::State::IDLE) : Stream
       @mutex.synchronize do
         if max = @connection.remote_settings.max_concurrent_streams
-          if unsafe_active_count(0) >= max
-            raise Error.internal_error("MAXIMUM outgoing stream capacity reached")
+          if unsafe_active_count_initiated_by(@local_endpoint) >= max
+            raise Error.refused_stream("MAXIMUM locally initiated stream capacity reached")
           end
         end
         id = @id_counter += 2
@@ -68,14 +90,13 @@ module HTTP2
       end
     end
 
-    # Counts active ingnoring (type=1) or outgoing (type=0) streams.
-    protected def active_count(type) : Int32
-      @mutex.synchronize { unsafe_active_count(type) }
+    protected def active_remote_count : Int32
+      @mutex.synchronize { unsafe_active_count_initiated_by(@remote_endpoint) }
     end
 
-    private def unsafe_active_count(type) : Int32
+    private def unsafe_active_count_initiated_by(endpoint : Endpoint) : Int32
       @streams.reduce(0) do |count, (_, stream)|
-        if stream.id == 0 || stream.id % 2 == type && stream.active?
+        if endpoint.initiates?(stream.id) && stream.active?
           count + 1
         else
           count

--- a/test/connection_test.cr
+++ b/test/connection_test.cr
@@ -1,0 +1,75 @@
+require "./test_helper"
+require "../src/connection"
+
+module HTTP2
+  class ConnectionTest < Minitest::Test
+    def test_client_respects_server_advertised_max_concurrent_streams
+      io = io_with(max_concurrent_streams_frame(1))
+      connection = Connection.new(io, Connection::Type::CLIENT)
+      connection.receive
+
+      stream = connection.streams.create(state: Stream::State::OPEN)
+      assert_equal 1, stream.id
+
+      error = assert_raises(Error) { connection.streams.create }
+      assert_equal Error::Code::REFUSED_STREAM, error.code
+    end
+
+    def test_server_respects_client_advertised_max_concurrent_streams
+      io = io_with(max_concurrent_streams_frame(1))
+      connection = Connection.new(io, Connection::Type::SERVER)
+      connection.receive
+
+      stream = connection.streams.create(state: Stream::State::OPEN)
+      assert_equal 2, stream.id
+
+      error = assert_raises(Error) { connection.streams.create }
+      assert_equal Error::Code::REFUSED_STREAM, error.code
+    end
+
+    def test_server_enforces_local_max_concurrent_streams_for_client_initiated_streams
+      headers = HPACK::Encoder.new(huffman: false).encode(HTTP::Headers{
+        ":method"    => "GET",
+        ":scheme"    => "http",
+        ":authority" => "example.com",
+        ":path"      => "/",
+      })
+      io = IO::Memory.new(
+        raw_frame(Frame::Type::HEADERS, Frame::Flags::END_HEADERS, 1, headers) +
+        raw_frame(Frame::Type::HEADERS, Frame::Flags::END_HEADERS, 3, headers)
+      )
+      connection = Connection.new(io, Connection::Type::SERVER)
+      connection.local_settings.max_concurrent_streams = 1
+
+      connection.receive
+      error = assert_raises(Error) { connection.receive }
+      assert_equal Error::Code::REFUSED_STREAM, error.code
+    end
+
+    private def max_concurrent_streams_frame(value)
+      raw_frame(Frame::Type::SETTINGS, Frame::Flags::None, 0, Bytes[0, 3, 0, 0, 0, value.to_u8])
+    end
+
+    private def io_with(bytes)
+      IO::Memory.new.tap do |io|
+        io.write(bytes)
+        io.rewind
+      end
+    end
+
+    private def raw_frame(type, flags, stream_id, payload = Bytes.empty)
+      frame = IO::Memory.new
+      frame.write_byte(((payload.size >> 16) & 0xff).to_u8)
+      frame.write_byte(((payload.size >> 8) & 0xff).to_u8)
+      frame.write_byte((payload.size & 0xff).to_u8)
+      frame.write_byte(type.value.to_u8)
+      frame.write_byte(flags.value.to_u8)
+      frame.write_byte(((stream_id >> 24) & 0x7f).to_u8)
+      frame.write_byte(((stream_id >> 16) & 0xff).to_u8)
+      frame.write_byte(((stream_id >> 8) & 0xff).to_u8)
+      frame.write_byte((stream_id & 0xff).to_u8)
+      frame.write(payload)
+      frame.to_slice
+    end
+  end
+end


### PR DESCRIPTION
The stream manager counted stream 0 when enforcing SETTINGS_MAX_CONCURRENT_STREAMS and used a fixed parity for outgoing streams. On a client connection, that meant a peer advertising MAX_CONCURRENT_STREAMS=1 could prevent even the first request stream from being created because the control stream was already counted.

This came up while making HTTP/2 connection leasing respect the peer concurrency limit. A client should be able to open one active request stream when the peer advertises a limit of one, and should refuse only the next concurrent stream. The fix records inbound and outbound stream parity from the connection type, excludes stream 0 from active counts, and raises REFUSED_STREAM when the outgoing limit is reached.

I tried to simplify the surrounding code for future readers; I can probably break this into two commits if needed.

(AI written, human verified.)
