### PR TITLE
Close stream data for HEADERS END_STREAM

### DIFF
--- a/src/connection.cr
+++ b/src/connection.cr
@@ -248,7 +248,7 @@ module HTTP2
           raise Error.compression_error
         end
 
-        if stream.data?
+        if stream.data? || frame.flags.end_stream?
           # https://tools.ietf.org/html/rfc7540#section-8.1
           # https://tools.ietf.org/html/rfc7230#section-4.1.2
           stream.data.close_write

--- a/test/connection_test.cr
+++ b/test/connection_test.cr
@@ -1,0 +1,33 @@
+require "./test_helper"
+require "../src/connection"
+
+module HTTP2
+  class ConnectionTest < Minitest::Test
+    def test_headers_with_end_stream_closes_empty_body
+      headers = HPACK::Encoder.new(huffman: false).encode(HTTP::Headers{
+        ":status" => "204",
+      })
+      io = IO::Memory.new(raw_frame(Frame::Type::HEADERS, Frame::Flags::END_HEADERS | Frame::Flags::END_STREAM, 1, headers))
+      connection = Connection.new(io, Connection::Type::CLIENT)
+
+      frame = connection.receive.not_nil!
+      async { assert_equal "", frame.stream.data.gets_to_end }
+      wait(100.milliseconds)
+    end
+
+    private def raw_frame(type, flags, stream_id, payload = Bytes.empty)
+      frame = IO::Memory.new
+      frame.write_byte(((payload.size >> 16) & 0xff).to_u8)
+      frame.write_byte(((payload.size >> 8) & 0xff).to_u8)
+      frame.write_byte((payload.size & 0xff).to_u8)
+      frame.write_byte(type.value.to_u8)
+      frame.write_byte(flags.value.to_u8)
+      frame.write_byte(((stream_id >> 24) & 0x7f).to_u8)
+      frame.write_byte(((stream_id >> 16) & 0xff).to_u8)
+      frame.write_byte(((stream_id >> 8) & 0xff).to_u8)
+      frame.write_byte((stream_id & 0xff).to_u8)
+      frame.write(payload)
+      frame.to_slice
+    end
+  end
+end

--- a/test/test_helper.cr
+++ b/test/test_helper.cr
@@ -13,10 +13,16 @@ module AsyncTest
     super
   end
 
-  def wait
+  def wait(timeout : Time::Span? = nil)
+    started_at = Time.instant
+
     loop do
       Fiber.yield
       break if @done
+
+      if timeout && Time.instant - started_at >= timeout
+        flunk "async block did not finish within #{timeout}"
+      end
     end
 
     if exception = @exception

--- a/test/test_helper.cr
+++ b/test/test_helper.cr
@@ -20,7 +20,7 @@ module AsyncTest
       Fiber.yield
       break if @done
 
-      if timeout && Time.instant - started_at >= timeout
+      if timeout && started_at.elapsed >= timeout
         flunk "async block did not finish within #{timeout}"
       end
     end


### PR DESCRIPTION
A response or request may legally end on a HEADERS frame with END_STREAM set, for example a 204 response with no DATA frames. The existing reader decoded the headers but only closed the data buffer when DATA had already been received, leaving callers blocked while reading an empty body.

This came up while exercising HTTP/2 empty responses from a raw fixture. The client received response headers successfully, but Response#body waited forever because the stream data writer was never closed. The fix treats END_STREAM on HEADERS as a terminal body condition and closes the stream data buffer even when no DATA frames were seen.

I added timeout support to async due to the endless hang this issue originally caused.

(AI written, human reviewed.)
