### PR TITLE
Fix some fairly major memory leaks for long-running connections 

### DIFF
--- a/src/connection.cr
+++ b/src/connection.cr
@@ -169,27 +169,38 @@ module HTTP2
       end
     end
 
-    private def read_frame_header
-      buf = io.read_bytes(UInt32, IO::ByteFormat::BigEndian)
-      size, type = (buf >> 8).to_i, buf & 0xff
-      flags = Frame::Flags.new(read_byte)
-      _, stream_id = read_stream_id
+    private def read_frame_header : Frame
+      loop do
+        buf = io.read_bytes(UInt32, IO::ByteFormat::BigEndian)
+        size, type = (buf >> 8).to_i, buf & 0xff
+        flags = Frame::Flags.new(read_byte)
+        _, stream_id = read_stream_id
 
-      if size > remote_settings.max_frame_size
-        raise Error.frame_size_error
+        if size > remote_settings.max_frame_size
+          raise Error.frame_size_error
+        end
+
+        frame_type = Frame::Type.new(type.to_i)
+
+        # RFC 7540: WINDOW_UPDATE and RST_STREAM may be received for closed
+        # streams. Skip them so we don't re-create a removed stream entry.
+        if streams.recently_closed?(stream_id) &&
+            {Frame::Type::WINDOW_UPDATE, Frame::Type::RST_STREAM}.includes?(frame_type)
+          io.skip(size)
+          next
+        end
+
+        unless frame_type.priority? || streams.valid?(stream_id)
+          raise Error.protocol_error("INVALID stream_id ##{stream_id}")
+        end
+
+        stream = streams.find(stream_id, consume: !frame_type.priority?)
+        frame = Frame.new(frame_type, stream, flags, size: size)
+
+        Log.trace { "recv #{frame.debug(color: :light_cyan)}" }
+
+        return frame
       end
-
-      frame_type = Frame::Type.new(type.to_i)
-      unless frame_type.priority? || streams.valid?(stream_id)
-        raise Error.protocol_error("INVALID stream_id ##{stream_id}")
-      end
-
-      stream = streams.find(stream_id, consume: !frame_type.priority?)
-      frame = Frame.new(frame_type, stream, flags, size: size)
-
-      Log.trace { "recv #{frame.debug(color: :light_cyan)}" }
-
-      frame
     end
 
     private def read_data_frame(frame)
@@ -312,6 +323,9 @@ module HTTP2
     # decompressing everything
     private def read_headers_payload(frame, size)
       stream = frame.stream
+      max_size = remote_settings.max_header_list_size || 65_536
+
+      raise Error.protocol_error("HEADER list size exceeds limit") if size > max_size
 
       pointer = GC.malloc_atomic(size).as(UInt8*)
       io.read_fully(pointer.to_slice(size))
@@ -327,7 +341,8 @@ module HTTP2
           raise Error.protocol_error("EXPECTED continuation frame for stream ##{stream.id} not ##{frame.stream.id}")
         end
 
-        # FIXME: raise if the payload grows too big
+        raise Error.protocol_error("HEADER list size exceeds limit") if size + frame.size > max_size
+
         pointer = pointer.realloc(size + frame.size)
         io.read_fully((pointer + size).to_slice(frame.size))
 
@@ -561,6 +576,7 @@ module HTTP2
       @mutex.synchronize do
         unless closed?
           @closed = true
+          streams.clear
 
           unless io.closed? || !notify
             if error

--- a/src/data.cr
+++ b/src/data.cr
@@ -74,6 +74,7 @@ module HTTP2
     def close : Nil
       close_read
       close_write
+      @buffer = nil
     end
 
     # Returns the collected size in bytes of streamed DATA frames.

--- a/src/io/circular_buffer.cr
+++ b/src/io/circular_buffer.cr
@@ -87,6 +87,9 @@ class IO::CircularBuffer < IO
     @closed |= how
     reschedule_read_fiber
     reschedule_write_fiber
+    # Clear fiber references so closed buffers don't retain waiting fibers
+    @read_fiber = nil
+    @write_fiber = nil
   end
 
   def closed?(how : Closed = Closed::All)

--- a/src/stream.cr
+++ b/src/stream.cr
@@ -74,7 +74,7 @@ module HTTP2
     #
     # FIXME: reports `false` if a zero-sized DATA was received.
     protected def data? : Bool
-      data.size != 0
+      (d = @data) ? d.size != 0 : false
     end
 
     # Received body.
@@ -407,8 +407,21 @@ module HTTP2
       end
     end
 
-    private def state=(@state)
+    private def state=(new_state)
+      @state = new_state
       Log.trace { "; Stream is now #{state}" }
+      if new_state == State::CLOSED
+        release_buffers
+        connection.streams.remove(id)
+      end
+    end
+
+    # Releases stream buffers to allow GC to reclaim memory. Called when stream closes.
+    private def release_buffers : Nil
+      if d = @data
+        d.close
+        @data = nil
+      end
     end
 
     # :nodoc:

--- a/src/streams.cr
+++ b/src/streams.cr
@@ -70,7 +70,7 @@ module HTTP2
 
     # Counts active ingnoring (type=1) or outgoing (type=0) streams.
     protected def active_count(type) : Int32
-      @mutex.synchronize { active_count(type) }
+      @mutex.synchronize { unsafe_active_count(type) }
     end
 
     private def unsafe_active_count(type) : Int32

--- a/src/streams.cr
+++ b/src/streams.cr
@@ -1,10 +1,15 @@
 require "./stream"
 
 module HTTP2
+  # Maximum number of closed stream IDs to retain for late WINDOW_UPDATE/RST_STREAM
+  # frame handling (RFC 7540). Prevents unbounded memory growth on long-lived connections.
+  MAX_CLOSED_STREAM_IDS = 10_000
+
   class Streams
     # :nodoc:
     protected def initialize(@connection : Connection, type : Connection::Type)
       @streams = {} of Int32 => Stream
+      @closed_stream_ids = [] of Int32
       @mutex = Mutex.new  # OPTIMIZE: use Sync::RWLock instead
       @highest_remote_id = 0
 
@@ -12,6 +17,39 @@ module HTTP2
         @id_counter = 0
       else
         @id_counter = -1
+      end
+    end
+
+    # Removes a closed stream from the active map. Retains its ID so that late
+    # WINDOW_UPDATE / RST_STREAM frames (permitted by RFC 7540) can be
+    # identified and skipped without re-creating the stream entry.
+    # Bounded to MAX_CLOSED_STREAM_IDS to prevent unbounded memory growth.
+    protected def remove(id : Int32) : Nil
+      return if id == 0
+      @mutex.synchronize do
+        @streams.delete(id)
+        unless @closed_stream_ids.includes?(id)
+          @closed_stream_ids << id
+          prune_closed_stream_ids if @closed_stream_ids.size > MAX_CLOSED_STREAM_IDS
+        end
+      end
+    end
+
+    private def prune_closed_stream_ids : Nil
+      excess = @closed_stream_ids.size - MAX_CLOSED_STREAM_IDS
+      @closed_stream_ids = @closed_stream_ids[excess..] if excess > 0
+    end
+
+    # Returns true if the stream was closed and removed from the active map.
+    protected def recently_closed?(id : Int32) : Bool
+      @mutex.synchronize { @closed_stream_ids.includes?(id) }
+    end
+
+    # Releases all stream and closed-ID references. Called when the connection closes.
+    protected def clear : Nil
+      @mutex.synchronize do
+        @streams.clear
+        @closed_stream_ids.clear
       end
     end
 


### PR DESCRIPTION
Hey so whilst using this shard in long-running connections to etcd I noticed some memory leaks... this isn't necessarily the best way to plug them but consider it a starting point and it does seem to drastically improve memory creep over time. 

Adding a loop in read_frame_header seemed sketchy tho, so if there's a cleaner way to solve it that would be great.

Thanks for all your work on this!